### PR TITLE
Move logo README to its own directory

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,8 +186,6 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
-
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [rust-cloud-native.github.io](rust-cloud-native.github.io)
+# [rust-cloud-native.github.io](https://rust-cloud-native.github.io)
 
 A collection of resources about cloud native Rust.
 
@@ -13,14 +13,3 @@ This repository follows and enforces the Rust programming language's [Code of Co
 ## License
 
 This repository is licensed under [Apache 2.0](./LICENSE).
-
-## Logo
-
-The logo can be found in the [logo](./docs/logo) directory.
-It was created with the following sources:
-
-Source | Host | License | Author
---- | --- | --- | ---
-["Happy" Ferris](https://rustacean.net/assets/rustacean-flat-happy.svg) | [rustacean.net](https://rustacean.net) | [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/) |[Karen Rustad Tölva](https://rustacean.net)
-[A cloud SVG](https://search.creativecommons.org/photos/47ed4673-7c56-4a25-86b7-4f28a93cc432) | [creativecommons.org](https://creativecommons.org) | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0?ref=ccsearch&atype=rich) | [Webalys](https://twitter.com/webalys)
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,12 +2,13 @@ A collection of resources about cloud native [Rust](https://rust-lang.org).
 
 <img src="./logo/rust-cloud-native-logo.png" alt="rust-cloud-native-logo" width="300">
 
+_This site belongs to the [Rust Cloud Native](https://github.com/rust-cloud-native/) GitHub organization._
+
 ## Status
 
 This page is under construction.
-[Contribute if you would like](https://github.com/rust-cloud-native/rust-cloud-native.github.io)!
+[We are looking for contributions, and would love new PRs, issues, and discussion posts.](https://github.com/rust-cloud-native/rust-cloud-native.github.io)!
 
-## Additional Information
- 
-- Created by [Nick Gerace](https://twitter.com/nickgeracehacks)
-- Belongs to the [Rust Cloud Native GitHub organization](https://github.com/rust-cloud-native/)
+## Logo
+
+More information about the logo can be found in the [core repository](https://github.com/rust-cloud-native/rust-cloud-native.github.io/blob/main/logo/README.md).

--- a/logo/README.md
+++ b/logo/README.md
@@ -1,0 +1,9 @@
+# Logo
+
+The logo `png` file can be found in the [logo](../docs/logo) directory.
+It was created with the following source images:
+
+Source | Host | License | Author
+--- | --- | --- | ---
+["Happy" Ferris](https://rustacean.net/assets/rustacean-flat-happy.svg) | [rustacean.net](https://rustacean.net) | [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/) |[Karen Rustad Tölva](https://rustacean.net)
+[A cloud SVG](https://search.creativecommons.org/photos/47ed4673-7c56-4a25-86b7-4f28a93cc432) | [creativecommons.org](https://creativecommons.org) | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0?ref=ccsearch&atype=rich) | [Webalys](https://twitter.com/webalys)


### PR DESCRIPTION
Move logo README to its own directory. Remove creator reference on the
main site. Fix README hyperlink. Reference logo source on the main page.

Closes #4 
Relevant #6