### PR TITLE
add qovery to libraries

### DIFF
--- a/data.json
+++ b/data.json
@@ -105,7 +105,7 @@
     {
       "title": "qovery/engine",
       "url": "https://github.com/Qovery/engine",
-      "description": "An open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers."
+      "description": "An open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers"
     }
   ],
   "events": [

--- a/data.json
+++ b/data.json
@@ -101,6 +101,11 @@
       "title": "kube-rs/kube-rs",
       "url": "https://github.com/kube-rs/kube-rs",
       "description": "Kubernetes Rust client and async controller runtime"
+    },
+    {
+      "title": "qovery/engine",
+      "url": "https://github.com/Qovery/engine",
+      "description": "An open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers."
     }
   ],
   "events": [

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ Explicit consent from maintainers and owners must be given for affiliation.
 - **[CNI Plugins](https://github.com/passcod/cni-plugins)**: crate/framework to write CNI (container networking) plugins in Rust (includes a few custom plugins as well)
 - **[containers/libkrun](https://github.com/containers/libkrun)**: a dynamic library providing Virtualization-based process isolation capabilities
 - **[kube-rs/kube-rs](https://github.com/kube-rs/kube-rs)**: Kubernetes Rust client and async controller runtime
-- **[qovery/engine](https://github.com/Qovery/engine)**: Qovery Engine is an open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers in just a few minutes.
+- **[qovery/engine](https://github.com/Qovery/engine)**: Qovery Engine is an open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers in just a few minutes
 <!-- end libraries -->
 
 ### Events

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ Explicit consent from maintainers and owners must be given for affiliation.
 - **[CNI Plugins](https://github.com/passcod/cni-plugins)**: crate/framework to write CNI (container networking) plugins in Rust (includes a few custom plugins as well)
 - **[containers/libkrun](https://github.com/containers/libkrun)**: a dynamic library providing Virtualization-based process isolation capabilities
 - **[kube-rs/kube-rs](https://github.com/kube-rs/kube-rs)**: Kubernetes Rust client and async controller runtime
+- **[qovery/engine](https://github.com/Qovery/engine)**: Qovery Engine is an open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers in just a few minutes.
 <!-- end libraries -->
 
 ### Events


### PR DESCRIPTION
Hi All, 
            This pr adds the [qovery engine](https://github.com/Qovery/engine) to the libraries section.  A little intro about the `engine`

```
Qovery Engine is an open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers in just a few minutes. The Qovery Engine is written in Rust and takes advantage of Terraform, Helm, Kubectl, and Docker to manage resources.
```

Closes #52

Thanks!