### PR TITLE
Switch from GitHub Discussions to Discord and misc changes

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,26 @@
+on: push
+jobs:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: rustfmt, clippy
+    - uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+    - uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: -- -D warnings
+    - uses: actions-rs/cargo@v1
+      with:
+        command: run
+    - run: |
+        if ! [ -z "$(git status --porcelain)" ]; then
+          exit 1
+        fi

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For now, we are focused on our aforementioned goals with the intent to provide a
 ## What can I do to help?
 
 In the short term, all we ask is your ideas, project additions, and feedback.
-You can provide these by finding, filing and starting [issues](https://github.com/rust-cloud-native/rust-cloud-native.github.io/issues), [pull requests](https://github.com/rust-cloud-native/rust-cloud-native.github.io/pulls), and [discussions](https://github.com/rust-cloud-native/rust-cloud-native.github.io/discussions)!
+You can provide these by finding, filing and starting [issues](https://github.com/rust-cloud-native/rust-cloud-native.github.io/issues), [pull requests](https://github.com/rust-cloud-native/rust-cloud-native.github.io/pulls), and [Discord discussions](https://discord.gg/799cmsYB4q)!
 
 This organization is our community's canvas.
 Let's paint it.
@@ -58,7 +58,7 @@ To apply to become a member of the team, please fill out the application via the
 You can nominate or self-request membership, and the only requirement is that you do not have a track record of consistent violations to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 Decisions are made on the same public GitHub issues and not in private chats, meetings or forums.
-Please feel free to open a [discussion](https://github.com/rust-cloud-native/rust-cloud-native.github.io/discussions) if you have any questions about the process.
+Please feel free to open a [discussion](https://discord.gg/799cmsYB4q) if you have any questions about the process.
 
 ## Code of Conduct
 

--- a/data.json
+++ b/data.json
@@ -108,22 +108,14 @@
       "description": "Kubernetes Rust client and async controller runtime"
     },
     {
-      "title": "qovery/engine",
-      "url": "https://github.com/Qovery/engine",
-      "description": "An open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers"
-    },
-    {
       "title": "open-telemetry/opentelemetry-rust",
       "url": "https://github.com/open-telemetry/opentelemetry-rust",
       "description": "OpenTelemetry is a set of APIs, SDKs, tooling and integrations that are designed for the creation and management of telemetry data such as traces, metrics, and logs."
-    }
-  ],
-  "events": [
+    },
     {
-      "title": "Cloud Native Rust Day EU 2021",
-      "url": "https://www.youtube.com/playlist?list=PLj6h78yzYM2MKPAas7pxIvueTbwFqVRCX",
-      "description": "the first-ever Cloud Native Rust Day (at KubeCon + CloudNativeCon EU 2021)"
+      "title": "qovery/engine",
+      "url": "https://github.com/Qovery/engine",
+      "description": "An open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers"
     }
   ]
 }
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ Rust Cloud Native
 </h3>
 <p align="center">
 A collection of resources about cloud native <a href="https://rust-lang.org">Rust</a>.
+<br>This site's source code and the organization's goals, charters, etc. are located in the <a href="https://github.com/rust-cloud-native/rust-cloud-native.github.io">core repository</a>.</br>
 </p>
 
 ## Meetup
@@ -15,17 +16,18 @@ Feel free to join and propose agenda items!
 
 ## Discussion and Collaboration
 
-We are currently using GitHub Issues and GitHub Discussions to track new ideas, feedback, collaboration, and community building.
-In addition, we now have a [Discord server](https://discord.gg/799cmsYB4q) for a real-time chat platform.
+[![Discord](https://img.shields.io/discord/874314181191565453?label=discord&style=flat-square&logo=discord)](https://discord.gg/799cmsYB4q)
+
+We are currently using GitHub Issues and our [Discord server](https://discord.gg/799cmsYB4q) to track new ideas, feedback, collaboration, and community building.
 Please do not hesitate to post, talk, and share your ideas.
 Let your voice be heard!
 
-Topic | Description | [Find or file an issue?](https://github.com/rust-cloud-native/rust-cloud-native.github.io/issues) | [Find or start a discussion?](https://github.com/rust-cloud-native/rust-cloud-native.github.io/discussions)
+Topic | Description | [Find or file an issue?](https://github.com/rust-cloud-native/rust-cloud-native.github.io/issues) | [Find or start a discussion in Discord?](https://discord.gg/799cmsYB4q)
 --- | --- | --- | ---
-Community | sharing, promoting, job posting, finding people to work on projects with, etc. | no | yes
-Projects | additions or changes to projects on the website | yes | no
-Technical | bugs, enhancements, features, etc. | yes | no (unless high-level, design-related)
-Organizational | "meta", goals, structure, etc. | no | yes
+Community | sharing, promoting, job posting, finding people to work on projects with, etc. | 🚫 | ✅
+Projects | additions or changes to projects on the website | ✅ | 🚫
+Technical | bugs, enhancements, features, etc. | ✅ | ⚠️
+Organizational | "meta", goals, structure, etc. | 🚫 | ✅
 
 ## Featured Projects
 
@@ -42,7 +44,7 @@ Explicit consent from maintainers and owners must be given for affiliation.
 - **[containers/youki](https://github.com/containers/youki)**: a container runtime written in Rust
 - **[datafuselabs/datafuse](https://github.com/datafuselabs/datafuse)**: A Modern Real-Time Data Processing & Analytics DBMS with Cloud-Native Architecture, built to make the Data Cloud easy
 - **[firecracker-microvm/firecracker](https://github.com/firecracker-microvm/firecracker)**: secure and fast microVMs for serverless computing
-- **[infinyon/fluvio](https://github.com/infinyon/fluvio)**: Cloud-native real-time data streaming platform with in-line computation capabilities
+- **[infinyon/fluvio](https://github.com/infinyon/fluvio)**: A cloud-native real-time data streaming platform with in-line computation capabilities
 - **[krustlet/krustlet](https://github.com/krustlet/krustlet)**: Kubernetes Rust Kubelet
 - **[kube-rs/controller-rs](https://github.com/kube-rs/controller-rs)**: a Kubernetes example controller
 - **[kube-rs/version-rs](https://github.com/kube-rs/version-rs)**: example Kubernetes reflector and web server
@@ -62,24 +64,23 @@ Explicit consent from maintainers and owners must be given for affiliation.
 - **[CNI Plugins](https://github.com/passcod/cni-plugins)**: crate/framework to write CNI (container networking) plugins in Rust (includes a few custom plugins as well)
 - **[containers/libkrun](https://github.com/containers/libkrun)**: a dynamic library providing Virtualization-based process isolation capabilities
 - **[kube-rs/kube-rs](https://github.com/kube-rs/kube-rs)**: Kubernetes Rust client and async controller runtime
-- **[qovery/engine](https://github.com/Qovery/engine)**: Qovery Engine is an open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers in just a few minutes
 - **[open-telemetry/opentelemetry-rust](https://github.com/open-telemetry/opentelemetry-rust)**: OpenTelemetry is a set of APIs, SDKs, tooling and integrations that are designed for the creation and management of telemetry data such as traces, metrics, and logs.
+- **[qovery/engine](https://github.com/Qovery/engine)**: An open-source abstraction layer library that turns easy apps deployment on AWS, GCP, Azure, and other Cloud providers
 <!-- end libraries -->
 
 ### Events
 
 #### Upcoming
 
-<!-- start upcoming events -->
-- **[Cross-Team Collaboration Fun Times (22 Nov 2021)](https://rust-ctcft.github.io/ctcft/meetings/2021-11-22.html)**: cross-team collaboration in the Rust project
 - **[Rust Cloud Native online meetup (20 Dec 2021)](meetup/20-12-2021.md)**: the first meetup of our initiative!
-<!-- end upcoming events -->
+
+#### Ongoing
+
+- **[Cross-Team Collaboration Fun Times](https://rust-ctcft.github.io/ctcft)**: cross-team collaboration in the Rust project, where "Rust Cloud Native" participates as an interest group on a monthly-basis (or more!)
 
 #### Past
 
-<!-- start past events -->
 - **[Cloud Native Rust Day EU 2021](https://www.youtube.com/playlist?list=PLj6h78yzYM2MKPAas7pxIvueTbwFqVRCX)**: the first-ever Cloud Native Rust Day (at KubeCon + CloudNativeCon EU 2021)
-<!-- end past events -->
 
 ## Want to add something? Let's do it!
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,12 @@ const APP_START: &str = "<!-- start applications -->";
 const APP_END: &str = "<!-- end applications -->";
 const LIB_START: &str = "<!-- start libraries -->";
 const LIB_END: &str = "<!-- end libraries -->";
-const EVE_START: &str = "<!-- start events -->";
-const EVE_END: &str = "<!-- end events -->";
 
 #[derive(Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
 struct Data {
     // These fields are purposefully ordered for `data.json`.
     pub applications: Option<Vec<Project>>,
     pub libraries: Option<Vec<Project>>,
-    pub events: Option<Vec<Project>>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -54,13 +51,6 @@ fn format_data_json(data: &Data) -> Data {
             }
             None => None,
         },
-        events: match data.events.clone() {
-            Some(mut s) => {
-                s.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()));
-                Some(s)
-            }
-            None => None,
-        },
     }
 }
 
@@ -84,7 +74,7 @@ fn main() -> Result<()> {
     for line in index_contents.lines() {
         match locked {
             true => {
-                if line == APP_END || line == LIB_END || line == EVE_END {
+                if line == APP_END || line == LIB_END {
                     writeln!(&index_writer, "{}", line)?;
                     locked = false;
                 }
@@ -99,11 +89,6 @@ fn main() -> Result<()> {
                 } else if line == LIB_START {
                     if let Some(libraries) = &formatted_data.libraries {
                         process_projects(&mut index_writer, libraries)?;
-                    }
-                    locked = true;
-                } else if line == EVE_START {
-                    if let Some(events) = &formatted_data.events {
-                        process_projects(&mut index_writer, events)?;
                     }
                     locked = true;
                 }


### PR DESCRIPTION
## Description

This PR primarily focuses on switching from GitHub Discussions to our Discord server for extended communications. This has played out in practice and we should consider ensuring our community has one quality place for discussion.

This PR also includes misc fixes and housekeeping fixes that are technically unrelated, but I'd like to suggest to reviewers to be merged.

See live site: https://github.com/nickgerace/rust-cloud-native.github.io/blob/discord/docs/index.md

## Issues
Closes #50
Closes #70
Closes #71
Closes #73 
Closes #74
Closes #76
Related #72 (disablement would happen outside of the PR and is _optional_ even after this PR is merged)