### PR TITLE
Remove closing br brace for valid HTML5

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,26 +1,26 @@
 on: push
+name: merge
 jobs:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy
-    - uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
-    - uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: -- -D warnings
-    - uses: actions-rs/cargo@v1
-      with:
-        command: run
-    - run: |
-        if ! [ -z "$(git status --porcelain)" ]; then
-          exit 1
-        fi
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: "--all -- --check"
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: "-- -D warnings"
+      - uses: actions-rs/cargo@v1
+        with:
+          command: run
+      - shell: sh
+        run: if ! [ -z "$(git status --porcelain)" ]; then exit 1; fi

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ Rust Cloud Native
 </h3>
 <p align="center">
 A collection of resources about cloud native <a href="https://rust-lang.org">Rust</a>.
-<br>This site's source code and the organization's goals, charters, etc. are located in the <a href="https://github.com/rust-cloud-native/rust-cloud-native.github.io">core repository</a>.</br>
+<br>This site's source code and the organization's goals, charters, etc. are located in the <a href="https://github.com/rust-cloud-native/rust-cloud-native.github.io">core repository</a>.
 </p>
 
 ## Meetup


### PR DESCRIPTION
Fixes a mistake introduced in the following commit: d7d6d00d24412a0e9ad53f5584acd0423e70ea9e
You can see it in the live site: https://rust-cloud-native.github.io/

Related issue: https://github.com/rust-cloud-native/rust-cloud-native.github.io/issues/50

Just adding the previous merger for review, @vadorovsky.